### PR TITLE
Set `basename` for react router

### DIFF
--- a/my_app/src/App.js
+++ b/my_app/src/App.js
@@ -24,7 +24,7 @@ function App() {
     setApiKey(newApiKey);
   }
   return (
-    <Router>
+    <Router basename="/yumemi-frontend">
       <Routes>
         <Route
           exact


### PR DESCRIPTION
The blank screen is displayed because you changed the path from `/` to `/yumemi-frontend` so that you can host the website on GitHub pages. The problem is that React Router doesn't know of the change and because no page corresponds to `/yumemi-frontend`, no component is rendered.

The fix is to use https://reactrouter.com/docs/en/v6/routers/router#:~:text=the%20%3Crouter%20basename%3E%20prop%20may%20be%20used%20to%20make%20all%20routes%20and%20links%20in%20your%20app%20relative%20to%20a%20%22base%22%20portion%20of%20the%20url%20pathname%20that%20they%20all%20share